### PR TITLE
Refactor: switch from hosted Mistral API to local LM Studio with direc…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 /.cargo/config.toml
 .env
+
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ tracing-subscriber = { version = "0.3", features = [
     "fmt",
 ] }
 reqwest = { version = "0.12", features = ["json"] }
-llm = { version = "1.3", features = ["mistral"] }
+llm = { version = "1.3", features = ["mistral", "openai"] }
 # schemars = { version = "1", features = ["derive"] }
 
 [profile.release]

--- a/src/api.rs
+++ b/src/api.rs
@@ -3,27 +3,20 @@ use axum::{
     http::{HeaderMap, StatusCode},
     response::IntoResponse,
 };
+use reqwest;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-use llm::{
-    // FunctionCall, ToolCall,
-    builder::{LLMBackend, LLMBuilder},
-    chat::{ChatMessage, StructuredOutputFormat},
-};
-
 use rmcp::{
-    ServiceExt,
     model::{CallToolRequestParam, ClientCapabilities, ClientInfo, Implementation},
     transport::StreamableHttpClientTransport,
+    ServiceExt,
 };
 
 use crate::mcp::{DatasetSummary, SearchResult};
 
 pub const ADDRESS: &str = "0.0.0.0:8000";
 const SYSTEM_PROMPT: &str = "Given the user question and datasets retrieved from the search API, summarize the findings in 1 sentence, extract which datasets might be the most interesting to answer the user question, and give them a relevance score between 0 and 1";
-// const DEFAULT_MODEL: &str = "mistral-small-latest";
-// const DEFAULT_MODEL: &str = "mistral-medium-latest";
 
 /// Represents a message in the chat
 #[derive(Debug, Deserialize, Serialize, ToSchema)]
@@ -56,7 +49,7 @@ struct EnhancedDataset {
     zenodo_url: String,
 }
 
-/// LLM response format
+/// LLM response format for structured output
 #[derive(Debug, Deserialize, Serialize)]
 struct LLMResponse {
     summary: String,
@@ -89,17 +82,14 @@ pub async fn search_handler(
             );
         }
     }
-    let api_key = match std::env::var("MISTRAL_API_KEY") {
-        Ok(key) => key,
-        Err(_) => {
-            // eprintln!("MISTRAL_API_KEY environment variable not set");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({"error": "MISTRAL_API_KEY environment variable not set"})),
-            );
-        }
-    };
-    // let llm_model = std::env::var("MISTRAL_MODEL").unwrap_or(DEFAULT_MODEL.into());
+
+    // Configure local LLM settings
+    let local_base_url = std::env::var("LOCAL_LLM_BASE_URL")
+        .unwrap_or_else(|_| "http://localhost:1234/v1".to_string());
+    let local_model = std::env::var("LOCAL_LLM_MODEL")
+        .unwrap_or_else(|_| "mistralai/mistral-small-3.2".to_string());
+
+    tracing::info!("Local LLM config - URL: {}, Model: {}", local_base_url, local_model);
 
     // Connect to MCP server
     let transport = StreamableHttpClientTransport::from_uri(format!("http://{ADDRESS}/mcp"));
@@ -118,84 +108,16 @@ pub async fn search_handler(
             tracing::error!("client error: {:?}", e);
         })
         .unwrap();
-    // Check server info
-    // let server_info = client.peer_info();
-    // tracing::info!("Connected to server: {server_info:#?}");
 
-    // Convert input messages to llm ChatMessage format, replacing last message content with tool result
-    // let mut search_resp = SearchResponse {
-    //     model: llm_model,
-    //     messages: messages
-    // };
-
-    // Define a simple JSON schema for structured output
-    let schema = r#"
-        {
-            "name": "search_results",
-            "schema": {
-                "type": "object",
-                "properties": {
-                    "summary": {
-                        "type": "string",
-                        "description": "Summary of the findings in 1 sentence"
-                    },
-                    "datasets": {
-                        "type": "array",
-                        "description": "List of most relevant datasets",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "doi": {
-                                    "type": "string",
-                                    "description": "Digital Object Identifier of the dataset"
-                                },
-                                "score": {
-                                    "type": "number",
-                                    "description": "Relevance score of the dataset based on the search query (between 0 and 1)"
-                                }
-                            },
-                            "additionalProperties": false,
-                            "required": ["doi", "score"]
-                        }
-                    }
-                },
-                "additionalProperties": false,
-                "required": ["summary", "datasets"]
-            },
-            "strict": true
-        }
-    "#;
-    let schema: StructuredOutputFormat = serde_json::from_str(schema).unwrap();
-
-    // Configure Mistral LLM client with dynamic tools from MCP
-    let llm_builder = LLMBuilder::new()
-        .backend(LLMBackend::Mistral)
-        .api_key(api_key)
-        .model(&resp.model)
-        .max_tokens(512)
-        .temperature(0.1)
-        .stream(false)
-        .system(SYSTEM_PROMPT)
-        .schema(schema);
-
-    // // Convert MCP tools to LLM functions and add them to the llm builder
-    // let tools = client.list_tools(Default::default()).await.unwrap();
-    // tracing::info!("Available tools: {tools:#?}");
-    // for tool in &tools.tools {
-    //     let schema_value = serde_json::Value::Object(tool.input_schema.as_ref().clone());
-    //     let function = FunctionBuilder::new(tool.name.to_string())
-    //         .description(tool.description.as_deref().unwrap_or(""))
-    //         .json_schema(schema_value);
-    //     llm_builder = llm_builder.function(function);
-    // }
-    let llm = llm_builder.build().expect("Failed to build LLM client");
-
-    // Call a MCP tool
+    // Call MCP tool to search for datasets
     let last_message_content = resp
         .messages
         .last()
         .map(|msg| msg.content.as_str())
         .unwrap_or("");
+
+    tracing::info!("Making MCP tool call with question: {}", last_message_content);
+
     let tool_results = client
         .call_tool(CallToolRequestParam {
             name: "search_data".into(),
@@ -205,6 +127,7 @@ pub async fn search_handler(
         })
         .await
         .expect("MCP tool call failed");
+
     // Extract and parse structured JSON content from the tool result
     let tool_result_text = tool_results
         .content
@@ -216,7 +139,9 @@ pub async fn search_handler(
         .collect::<Vec<_>>()
         .join(" ");
 
-    // Parse the structured JSON response from MCP search data tool and format it for the LLM
+    tracing::info!("MCP tool result length: {} chars", tool_result_text.len());
+
+    // Parse and format the search results for the LLM
     let formatted_context = match serde_json::from_str::<SearchResult>(&tool_result_text) {
         Ok(search_result) => {
             if search_result.total_found == 0 {
@@ -250,152 +175,153 @@ pub async fn search_handler(
         }
         Err(e) => {
             eprintln!("Failed to parse search result JSON: {}", e);
-            // Fallback to raw text if JSON parsing fails
             tool_result_text.clone()
         }
     };
 
-    // Convert messages to LLM ChatMessage format, replacing last message content with formatted context
-    let chat_messages: Vec<ChatMessage> = resp
-        .messages
-        .iter()
-        .enumerate()
-        .map(|(i, msg)| {
-            let content = if i == resp.messages.len() - 1 {
-                &format!("{}\n\n{}", &msg.content, formatted_context)
-            } else {
-                &msg.content
-            };
-            match msg.role.as_str() {
-                "user" => ChatMessage::user().content(content).build(),
-                "assistant" => ChatMessage::assistant().content(content).build(),
-                _ => ChatMessage::user().content(content).build(), // Default to user if unknown role
+    // Prepare request for local LLM
+    let llm_request = serde_json::json!({
+        "model": local_model,
+        "messages": [
+            {
+                "role": "system",
+                "content": SYSTEM_PROMPT
+            },
+            {
+                "role": "user",
+                "content": format!("{}\n\nContext:\n{}", last_message_content, formatted_context)
             }
-        })
-        .collect();
+        ],
+        "temperature": 0.1,
+        "max_tokens": 512,
+        "stream": false
+    });
 
-    // TODO: call with structured output to retrieve the list of most relevant according to the LLM
+    tracing::info!("About to send request to LLM at {}/chat/completions", local_base_url);
 
-    // Send chat request using additional infos retrieved by the tool call
-    match llm.chat(&chat_messages).await {
+    // Make direct HTTP request to local LLM (LM Studio)
+    let http_client = reqwest::Client::new();
+    let response = http_client
+        .post(&format!("{}/chat/completions", local_base_url))
+        .header("Content-Type", "application/json")
+        .json(&llm_request)
+        .send()
+        .await;
+
+    match response {
         Ok(response) => {
-            // Parse the JSON response from the LLM (structured output)
-            let response_text = response.text().unwrap_or_default();
-            match serde_json::from_str::<LLMResponse>(&response_text) {
-                Ok(llm_response) => {
-                    // Parse the original search results to get full dataset metadata
-                    let search_result = serde_json::from_str::<SearchResult>(&tool_result_text)
-                        .unwrap_or_else(|_| SearchResult {
-                            total_found: 0,
-                            query: String::new(),
-                            datasets: vec![],
-                        });
+            let status = response.status();
+            if status.is_success() {
+                match response.json::<serde_json::Value>().await {
+                    Ok(json_response) => {
+                        tracing::info!("LLM response received successfully");
 
-                    // Create a lookup map for full dataset info by DOI
-                    let dataset_lookup: std::collections::HashMap<String, &DatasetSummary> = search_result
-                        .datasets
-                        .iter()
-                        .filter_map(|ds| ds.doi.as_ref().map(|doi| (format!("https://doi.org/{}", doi), ds)))
-                        .collect();
+                        // Extract the response text from OpenAI format
+                        let response_text = json_response
+                            .get("choices")
+                            .and_then(|choices| choices.get(0))
+                            .and_then(|choice| choice.get("message"))
+                            .and_then(|message| message.get("content"))
+                            .and_then(|content| content.as_str())
+                            .unwrap_or("No response content found");
 
-                    // Enrich LLM datasets with full metadata
-                    let enhanced_datasets: Vec<EnhancedDataset> = llm_response
-                        .datasets
-                        .into_iter()
-                        .filter_map(|llm_dataset| {
-                            dataset_lookup.get(&llm_dataset.doi).map(|full_dataset| EnhancedDataset {
-                                doi: llm_dataset.doi,
-                                score: llm_dataset.score,
-                                title: full_dataset.title.clone(),
-                                description: full_dataset.description.clone(),
-                                publication_date: full_dataset.publication_date.clone(),
-                                keywords: full_dataset.keywords.clone(),
-                                creators: full_dataset.creators.clone(),
-                                zenodo_url: full_dataset.zenodo_url.clone(),
-                            })
-                        })
-                        .collect();
+                        // Try to parse LLM response as structured JSON, fallback to text summary
+                        match serde_json::from_str::<LLMResponse>(&response_text) {
+                            Ok(llm_response) => {
+                                // Structured response: match LLM recommendations with full dataset metadata
+                                let search_result = serde_json::from_str::<SearchResult>(&tool_result_text)
+                                    .unwrap_or_else(|_| SearchResult {
+                                        total_found: 0,
+                                        query: String::new(),
+                                        datasets: vec![],
+                                    });
 
-                    let enhanced_response = serde_json::json!({
-                        "summary": llm_response.summary,
-                        "datasets": enhanced_datasets
-                    });
+                                let dataset_lookup: std::collections::HashMap<String, &DatasetSummary> = search_result
+                                    .datasets
+                                    .iter()
+                                    .filter_map(|ds| ds.doi.as_ref().map(|doi| (format!("https://doi.org/{}", doi), ds)))
+                                    .collect();
 
-                    return (StatusCode::OK, Json(enhanced_response));
+                                let enhanced_datasets: Vec<EnhancedDataset> = llm_response
+                                    .datasets
+                                    .into_iter()
+                                    .filter_map(|llm_dataset| {
+                                        dataset_lookup.get(&llm_dataset.doi).map(|full_dataset| EnhancedDataset {
+                                            doi: llm_dataset.doi,
+                                            score: llm_dataset.score,
+                                            title: full_dataset.title.clone(),
+                                            description: full_dataset.description.clone(),
+                                            publication_date: full_dataset.publication_date.clone(),
+                                            keywords: full_dataset.keywords.clone(),
+                                            creators: full_dataset.creators.clone(),
+                                            zenodo_url: full_dataset.zenodo_url.clone(),
+                                        })
+                                    })
+                                    .collect();
+
+                                let enhanced_response = serde_json::json!({
+                                    "summary": llm_response.summary,
+                                    "datasets": enhanced_datasets
+                                });
+
+                                return (StatusCode::OK, Json(enhanced_response));
+                            }
+                            Err(_) => {
+                                // Text response: use LLM text as summary with all datasets
+                                let search_result = serde_json::from_str::<SearchResult>(&tool_result_text)
+                                    .unwrap_or_else(|_| SearchResult {
+                                        total_found: 0,
+                                        query: String::new(),
+                                        datasets: vec![],
+                                    });
+
+                                let enhanced_datasets: Vec<EnhancedDataset> = search_result
+                                    .datasets
+                                    .into_iter()
+                                    .map(|dataset| EnhancedDataset {
+                                        doi: dataset.doi.map(|d| format!("https://doi.org/{}", d)).unwrap_or_default(),
+                                        score: 0.5, // Default score since LLM didn't provide structured output
+                                        title: dataset.title,
+                                        description: dataset.description,
+                                        publication_date: dataset.publication_date,
+                                        keywords: dataset.keywords,
+                                        creators: dataset.creators,
+                                        zenodo_url: dataset.zenodo_url,
+                                    })
+                                    .collect();
+
+                                let enhanced_response = serde_json::json!({
+                                    "summary": response_text,
+                                    "datasets": enhanced_datasets
+                                });
+
+                                return (StatusCode::OK, Json(enhanced_response));
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!("Failed to parse LLM response JSON: {}", e);
+                        return (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            Json(serde_json::json!({"error": format!("Failed to parse LLM response: {}", e)})),
+                        );
+                    }
                 }
-                Err(e) => {
-                    eprintln!("Failed to parse LLM response as JSON: {}", e);
-                    // Fallback: add to messages and return the original response format
-                    resp.messages.push(Message {
-                        role: "assistant".into(),
-                        content: response_text,
-                    });
-                }
+            } else {
+                let error_text = response.text().await.unwrap_or_else(|_| "Unknown error".to_string());
+                tracing::error!("LLM request failed with status {}: {}", status, error_text);
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": format!("LLM request failed: {}", error_text)})),
+                );
             }
         }
         Err(e) => {
-            eprintln!("Chat error: {e}");
+            tracing::error!("Failed to send request to LLM: {}", e);
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({"error": format!("Chat error: {}", e)})),
+                Json(serde_json::json!({"error": format!("Failed to connect to LLM: {}", e)})),
             );
         }
     }
-
-
-    // // Send chat request with tools is crashing after SEND
-    // // Chat error: Response Format Error: Failed to decode Mistral API response: missing field `type` at line 1 column 376. Raw response: {"id":"294dbcf061ef4b1cb5f82eb09bae6bea","created":1753771664,"model":"mistral-medium-2505","usage":{"prompt_tokens":647,"total_tokens":664,"completion_tokens":17},"object":"chat.completion","choices":[{"index":0,"finish_reason":"tool_calls","message":{"role":"assistant","tool_calls":[{"id":"jxsN10Cs0","function":{"name":"sum","arguments":"{\"a\": 5, \"b\": 76}"},"index":0}],"content":""}}]}
-    // // https://github.com/graniet/llm/blob/main/examples/openai_example.rs
-    // // Use tool calling with tools extracted from MCP server
-    // // https://github.com/graniet/llm/blob/main/examples/google_tool_calling_example.rs
-    // println!("SEND");
-    // match llm.chat_with_tools(&chat_messages, llm.tools()).await {
-    //     Ok(response) => {
-    //         println!("RESP");
-    //         if let Some(tool_calls) = response.tool_calls() {
-    //             println!("Tool calls requested:");
-    //             for call in &tool_calls {
-    //                 println!("Function: {}", call.function.name);
-    //                 println!("Arguments: {}", call.function.arguments);
-    //                 // let result = process_tool_call(call)?;
-    //                 // println!("Result: {}", serde_json::to_string_pretty(&result)?);
-    //             }
-    //             all_msgs.push(Message {
-    //                 role: "assistant".into(),
-    //                 content: response.text().unwrap_or_default(),
-    //             });
-    //             // let mut conversation = messages;
-    //             // conversation.push(
-    //             //     ChatMessage::assistant()
-    //             //         .tool_use(tool_calls.clone())
-    //             //         .build(),
-    //             // );
-    //             // let tool_results: Vec<ToolCall> = tool_calls
-    //             //     .iter()
-    //             //     .map(|call| {
-    //             //         let result = process_tool_call(call).unwrap();
-    //             //         ToolCall {
-    //             //             id: call.id.clone(),
-    //             //             call_type: "function".to_string(),
-    //             //             function: FunctionCall {
-    //             //                 name: call.function.name.clone(),
-    //             //                 arguments: serde_json::to_string(&result).unwrap(),
-    //             //             },
-    //             //         }
-    //             //     })
-    //             //     .collect();
-    //             // conversation.push(ChatMessage::user().tool_result(tool_results).build());
-    //             // let final_response = llm.chat_with_tools(&conversation, llm.tools()).await?;
-    //             // println!("\nFinal response: {}", final_response);
-    //         } else {
-    //             println!("Direct response: {}", response);
-    //             all_msgs.push(Message {
-    //                 role: "assistant".into(),
-    //                 content: response.text().unwrap_or_default(),
-    //             });
-    //         }
-    //     },
-    //     Err(e) => eprintln!("Chat error: {}", e),
-    // }
-    (StatusCode::OK, Json(serde_json::to_value(resp).unwrap()))
 }


### PR DESCRIPTION
This pull request introduces significant changes to the integration of local LLM (Language Learning Model) handling, replacing the previous Mistral-based implementation. The updates streamline the architecture, improve error handling, and enhance the flexibility of the system by enabling direct HTTP communication with a locally hosted LLM. Key changes include the addition of configuration for the local LLM, removal of Mistral-specific dependencies, and improved logging and error handling.

### Dependency Updates:
* Added `openai` feature to the `llm` dependency in `Cargo.toml` to extend LLM capabilities.

### Removal of Mistral-Specific Code:
* Removed Mistral-specific API key and model configuration, replacing it with local LLM settings (`LOCAL_LLM_BASE_URL` and `LOCAL_LLM_MODEL`) for enhanced flexibility.
* Deleted Mistral-specific LLM client setup, including schema definitions and tool integration, simplifying the implementation.

### Integration with Local LLM:
* Introduced direct HTTP requests to a locally hosted LLM using `reqwest`, including a JSON payload for chat completions.
* Enhanced logging to trace LLM request and response flows, aiding debugging and observability.

### Error Handling Improvements:
* Improved error handling for LLM responses, including structured JSON parsing, fallback mechanisms, and detailed logging for failures.

### Code Cleanup and Documentation:
* Removed unused imports and commented-out code related to Mistral, improving code readability and maintainability.
* Updated documentation to reflect the structured output format for the LLM response.