### PR TITLE
Small suggested adjustments from test run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /target
 /.cargo/config.toml
-.env
+*.env

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ cargo build --release
 
 ### 🐳 Deploy with Docker
 
-Create a `.env` file with the API keys:
+Create a `keys.env` file with the API keys:
 
 ```sh
 MISTRAL_API_KEY=YOUR_API_KEY

--- a/compose.yml
+++ b/compose.yml
@@ -6,4 +6,4 @@ services:
     environment:
       - RUST_LOG=info
     env_file:
-      - .env
+      - keys.env

--- a/compose.yml
+++ b/compose.yml
@@ -2,6 +2,8 @@ services:
   mcp:
     build: .
     ports:
-      - 8000:8000
+      - "127.0.0.1:8000:8000"
+    environment:
+      - RUST_LOG=info
     env_file:
       - .env


### PR DESCRIPTION
The LLM search works really well, congrats!

Just two suggested fixes:

* Only expose on `localhost` by default, don't run on public interfaces. For our data management we use https://docs.docker.com/compose/how-tos/production/ to distinguish test and production deployment.
* Rename `.env` to `keys.env`. I guess their documentation at https://docs.docker.com/compose/how-tos/environment-variables/set-environment-variables/ nudges users towards using `.env` as a file name. However, that one is hidden on Unix, which can complicate things like file opening.

CC @ritwikshanker 